### PR TITLE
fix(mobile): suggest field prevent focus

### DIFF
--- a/packages/mobile/src/suggest-field/SuggestField.tsx
+++ b/packages/mobile/src/suggest-field/SuggestField.tsx
@@ -61,7 +61,7 @@ export const SuggestField = <V extends {}>({
           >
             <InputField
               title={props.title}
-              active={renderProps.focused || !!props.suggest || !!props.placeholder}
+              active={!!props.suggest || !!props.placeholder}
               input={(
                 <BasicInput
                   ref={renderProps.inputRef}
@@ -76,7 +76,7 @@ export const SuggestField = <V extends {}>({
                   placeholder={props.placeholder}
                   maxLength={props.maxLength}
                   error={!!props.error}
-                  focused={renderProps.focused}
+                  focused={false}
                   onChange={renderProps.onRequest}
                   onFocus={renderProps.onShowFocus}
                   onBlur={renderProps.onInputBlur}


### PR DESCRIPTION
В мобильной версии саджеста у основного инпута не нужно сфокусированное состояние. В любом случае в этот инпут мы ничего ввести не можем. Ввод происходит только в инпуте на модалке. При этом после выбора элемента базовый инпут визуально остается в фокусе вне зависимости от того, какой элемент формы мы пытаемся выбрать так как на нем не срабатывает onBlur.