### PR TITLE
Add @qiwi/pijma-ssr

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,6 @@
     "@emotion/core": "^11.0.0",
     "@emotion/css": "^11.5.0",
     "@emotion/react": "^11.5.0",
-    "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@types/dom-helpers": "^3.4.1",
     "@types/markdown-to-jsx": "^6.9.0",

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled'
 import createCache from '@emotion/cache'
-import createEmotionServer from '@emotion/server/create-instance'
 
-export {
-  styled,
-  createCache,
-  createEmotionServer,
-}
+export {styled, createCache}
 
 export * from '@emotion/styled'
 export * from '@emotion/react'

--- a/packages/ssr/.releaserc.js
+++ b/packages/ssr/.releaserc.js
@@ -1,0 +1,36 @@
+module.exports = {
+  branch: 'master',
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules: [
+          {type: 'docs', release: 'patch'},
+          {type: 'doc', release: 'patch'},
+          {type: 'refactor', release: 'patch'},
+        ],
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+        },
+      },
+    ],
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/changelog',
+    '@semantic-release/npm',
+    [
+      '@semantic-release/github',
+      {
+        successComment: false,
+        failComment: false,
+      },
+    ],
+    [
+      '@semantic-release/git',
+      {
+        message:
+          'chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
+  ],
+}

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -1,0 +1,10 @@
+# @qiwi/pijma-ssr
+
+Pijma SSR utilities.
+
+## Install
+
+```bash
+npm i --save @qiwi/pijma-ssr
+yarn add @qiwi/pijma-ssr
+```

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@qiwi/pijma-ssr",
+  "version": "0.0.0",
+  "main": "./lib/es6/index.js",
+  "types": "./lib/es6/index.d.ts",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prebuild": "yarn clean",
+    "clean": "rimraf lib",
+    "build": "concurrently 'npm:build:*'",
+    "build:es6": "node ../infra/esbuild.js && tsc-esm-fix --target=lib/es6",
+    "build:libdef": "tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "lint": "eslint -c ../infra/.eslintrc.js 'src/**/*.ts{,x}'",
+    "lint:fix": "yarn lint --fix"
+  },
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "lib"
+  ],
+  "dependencies": {
+    "@emotion/server": "^11.4.0"
+  },
+  "devDependencies": {
+    "@qiwi/pijma-infra": "1.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qiwi/pijma.git"
+  },
+  "bugs": {
+    "url": "https://github.com/qiwi/pijma/issues"
+  },
+  "homepage": "https://github.com/qiwi/pijma/#readme"
+}

--- a/packages/ssr/src/emotionServer.ts
+++ b/packages/ssr/src/emotionServer.ts
@@ -1,0 +1,3 @@
+import createEmotionServer from '@emotion/server/create-instance'
+
+export {createEmotionServer}

--- a/packages/ssr/src/index.ts
+++ b/packages/ssr/src/index.ts
@@ -1,0 +1,1 @@
+export * from './emotionServer'

--- a/packages/ssr/tsconfig.build.json
+++ b/packages/ssr/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib/es6",
+    "baseUrl": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ssr/tsconfig.json
+++ b/packages/ssr/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,12 @@
       ],
       "@qiwi/pijma-fonts": [
         "./fonts"
+      ],
+      "@qiwi/pijma-ssr": [
+        "./ssr/src"
+      ],
+      "@qiwi/pijma-ssr/": [
+        "./ssr/src/*"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,7 +860,6 @@ __metadata:
     "@emotion/core": ^11.0.0
     "@emotion/css": ^11.5.0
     "@emotion/react": ^11.5.0
-    "@emotion/server": ^11.4.0
     "@emotion/styled": ^11.3.0
     "@qiwi/pijma-infra": 1.3.1
     "@types/dom-helpers": ^3.4.1
@@ -951,6 +950,15 @@ __metadata:
   dependencies:
     "@qiwi/pijma-core": 1.141.2
     "@qiwi/pijma-fonts": 1.0.0
+    "@qiwi/pijma-infra": 1.3.1
+  languageName: unknown
+  linkType: soft
+
+"@qiwi/pijma-ssr@workspace:packages/ssr":
+  version: 0.0.0-use.local
+  resolution: "@qiwi/pijma-ssr@workspace:packages/ssr"
+  dependencies:
+    "@emotion/server": ^11.4.0
     "@qiwi/pijma-infra": 1.3.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Импорт и сразу экспорт createEmotionServer приводит к тому что в бандл попадает код из emotion/server. 
на CRA 4 + webpack 4 это просто ведет к увеличенному бандлу
на CRA 5 + webpack 5 будет ошибка, так как шимминг node модулей по умолчанию отключен

Добавил /core/server/package.json, чтобы была возможность импортировать через `import { A } from "@qiwi/pijma-core/server"` вместо `from @qiwi/pijma-core/lib/es6/server`

