### PR TITLE
fix: masked input trigger change handler on remove whole value

### DIFF
--- a/packages/core/src/main/ts/mask/MaskedInput.tsx
+++ b/packages/core/src/main/ts/mask/MaskedInput.tsx
@@ -189,7 +189,8 @@ class MaskedInputComponent extends PureComponent<MaskedInputProps, {}> {
         ref={this.setRef}
         onBlur={this.onBlur}
         onChange={this.onChange}
-        defaultValue={this.props.value}
+        defaultValue=""
+        value={this.props.value}
         {...props}
       />
     )

--- a/packages/desktop-extra/src/test/ts/__snapshots__/datePicker.tsx.snap
+++ b/packages/desktop-extra/src/test/ts/__snapshots__/datePicker.tsx.snap
@@ -39,6 +39,7 @@ exports[`DatePicker renders correctly 1`] = `
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           type="text"
+          value=""
         />
         <div
           className="css-t03j0v"


### PR DESCRIPTION

https://github.com/qiwi/pijma/assets/131945009/ee2d40b1-5524-4baa-bb2a-8d69e55e2532

<!-- 
Add a link to issue, another PR, discussion with which this PR is associated.
Select the most suitable relation type: fixes / closes / relates
-->

This code fixes issue from text-mask-core https://github.com/text-mask/text-mask/issues/992. There is PR in text-mask-core but library is abandoned.

## Changes
<!-- What exactly you have changed, and how it works now -->

it removes defining `defaultValue` with `value`. And instead uses input's `value` property for external `value`.
