### PR TITLE
fix: masked input trigger change handler on remove whole value

### DIFF
--- a/packages/core/src/main/ts/mask/MaskedInput.tsx
+++ b/packages/core/src/main/ts/mask/MaskedInput.tsx
@@ -189,7 +189,7 @@ class MaskedInputComponent extends PureComponent<MaskedInputProps, {}> {
         ref={this.setRef}
         onBlur={this.onBlur}
         onChange={this.onChange}
-        defaultValue={this.props.value}
+        defaultValue=''
         {...props}
       />
     )


### PR DESCRIPTION
Relates to https://github.com/qiwi/pijma/pull/567

Fixes
Actual fix for issue from text-mask-core https://github.com/text-mask/text-mask/issues/992. There is PR in text-mask-core but library is abandoned.

## Changes
it removes defining defaultValue with value exactly as described here - https://github.com/text-mask/text-mask/issues/992

