### PR TITLE
fix: add swc/helpers as dependency

### DIFF
--- a/packages/desktop-extra/package.json
+++ b/packages/desktop-extra/package.json
@@ -35,6 +35,7 @@
     "@qiwi/common-formatters": "^1.2.2",
     "@qiwi/pijma-core": "workspace:*",
     "@qiwi/pijma-desktop": "workspace:*",
+    "@swc/helpers": "^0.5.1",
     "@types/react-js-pagination": "^3.0.4",
     "@types/react-table": "^7.7.14",
     "date-fns": "^2.30.0",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -39,7 +39,8 @@
     "target/es6/**/*"
   ],
   "dependencies": {
-    "@qiwi/pijma-core": "workspace:*"
+    "@qiwi/pijma-core": "workspace:*",
+    "@swc/helpers": "^0.5.1"
   },
   "devDependencies": {
     "@qiwi/pijma-infra": "workspace:*",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -39,7 +39,8 @@
     "target/es6/**/*"
   ],
   "dependencies": {
-    "@qiwi/pijma-core": "workspace:*"
+    "@qiwi/pijma-core": "workspace:*",
+    "@swc/helpers": "^0.5.1"
   },
   "devDependencies": {
     "@qiwi/pijma-infra": "workspace:*",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -31,7 +31,8 @@
     "target/es6/**/*"
   ],
   "dependencies": {
-    "@emotion/server": "^11.11.0"
+    "@emotion/server": "^11.11.0",
+    "@swc/helpers": "^0.5.1"
   },
   "devDependencies": {
     "@qiwi/pijma-infra": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,7 @@ __metadata:
     "@qiwi/pijma-core": "workspace:*"
     "@qiwi/pijma-desktop": "workspace:*"
     "@qiwi/pijma-infra": "workspace:*"
+    "@swc/helpers": "npm:^0.5.1"
     "@types/jest": "npm:^29.5.1"
     "@types/react-js-pagination": "npm:^3.0.4"
     "@types/react-table": "npm:^7.7.14"
@@ -1259,6 +1260,7 @@ __metadata:
   dependencies:
     "@qiwi/pijma-core": "workspace:*"
     "@qiwi/pijma-infra": "workspace:*"
+    "@swc/helpers": "npm:^0.5.1"
     concurrently: "npm:8.0.1"
     css-loader: "npm:6.7.3"
     eslint: "npm:8.40.0"
@@ -1316,6 +1318,7 @@ __metadata:
   dependencies:
     "@qiwi/pijma-core": "workspace:*"
     "@qiwi/pijma-infra": "workspace:*"
+    "@swc/helpers": "npm:^0.5.1"
     concurrently: "npm:8.0.1"
     css-loader: "npm:6.7.3"
     eslint: "npm:8.40.0"
@@ -1341,6 +1344,7 @@ __metadata:
   dependencies:
     "@emotion/server": "npm:^11.11.0"
     "@qiwi/pijma-infra": "workspace:*"
+    "@swc/helpers": "npm:^0.5.1"
     concurrently: "npm:8.0.1"
     css-loader: "npm:6.7.3"
     eslint: "npm:8.40.0"


### PR DESCRIPTION
Иногда в монорепах из-за хоистинга зависимостей в pijma-desktop используется не та версия @swc/helpers. Для фикса добавил прямую зависимость в каждый пакет