### PR TITLE
feat: remove typography default props

### DIFF
--- a/packages/desktop/src/main/ts/typography/Caption.tsx
+++ b/packages/desktop/src/main/ts/typography/Caption.tsx
@@ -64,7 +64,3 @@ export const Caption: FC<CaptionProps> = ({
   )
 
 Caption.displayName = 'Caption'
-
-Caption.defaultProps = {
-  color: 'support',
-}

--- a/packages/desktop/src/main/ts/typography/Heading.tsx
+++ b/packages/desktop/src/main/ts/typography/Heading.tsx
@@ -131,7 +131,3 @@ export const Heading: FC<HeadingProps> = ({
   )
 
 Heading.displayName = 'Heading'
-
-Heading.defaultProps = {
-  color: 'default',
-}

--- a/packages/desktop/src/main/ts/typography/Paragraph.tsx
+++ b/packages/desktop/src/main/ts/typography/Paragraph.tsx
@@ -141,10 +141,3 @@ export const Paragraph: FC<ParagraphProps> = ({
   )
 
 Paragraph.displayName = 'Paragraph'
-
-Paragraph.defaultProps = {
-  size: 'm',
-  bold: false,
-  compact: false,
-  color: 'default',
-}

--- a/packages/desktop/src/main/ts/typography/Title.tsx
+++ b/packages/desktop/src/main/ts/typography/Title.tsx
@@ -100,7 +100,3 @@ export const Title: FC<TitleProps> = ({
   )
 
 Title.displayName = 'Title'
-
-Title.defaultProps = {
-  color: 'default',
-}

--- a/packages/mobile/src/main/ts/typography/Caption.tsx
+++ b/packages/mobile/src/main/ts/typography/Caption.tsx
@@ -49,7 +49,3 @@ export const Caption: FC<CaptionProps> = ({
   )
 
 Caption.displayName = 'Caption'
-
-Caption.defaultProps = {
-  color: 'support',
-}

--- a/packages/mobile/src/main/ts/typography/Heading.tsx
+++ b/packages/mobile/src/main/ts/typography/Heading.tsx
@@ -115,7 +115,3 @@ export const Heading: FC<HeadingProps> = ({
   )
 
 Heading.displayName = 'Heading'
-
-Heading.defaultProps = {
-  color: 'default',
-}

--- a/packages/mobile/src/main/ts/typography/Paragraph.tsx
+++ b/packages/mobile/src/main/ts/typography/Paragraph.tsx
@@ -132,10 +132,3 @@ export const Paragraph: FC<ParagraphProps> = ({
   )
 
 Paragraph.displayName = 'Paragraph'
-
-Paragraph.defaultProps = {
-  size: 'm',
-  bold: false,
-  compact: false,
-  color: 'default',
-}

--- a/packages/mobile/src/main/ts/typography/Title.tsx
+++ b/packages/mobile/src/main/ts/typography/Title.tsx
@@ -91,7 +91,3 @@ export const Title: FC<TitleProps> = ({
   )
 
 Title.displayName = 'Title'
-
-Title.defaultProps = {
-  color: 'default',
-}


### PR DESCRIPTION
### Адаптация компонентов типографии под Next.js

Задача выросла из следующего предупреждения
> Warning: Heading: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.

Если при интеграции с кошельком никаких проблем не вылезет, планирую удалить defaultProps во всех компонентах

## Changes
Отказ от defaultProps в пользу JavaScript default parameters

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
