### PR TITLE
build(deps): bump markdown-to-jsx from 7.4.0 to 7.7.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@types/react-overlays": "^3.1.0",
     "@types/react-transition-group": "^4.4.6",
     "dom-helpers": "^5.2.1",
-    "markdown-to-jsx": "^7.4.0",
+    "markdown-to-jsx": "^7.7.3",
     "react-google-recaptcha": "^2.1.0",
     "react-intersection-observer": "^9.4.3",
     "react-overlays": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,7 +1327,7 @@ __metadata:
     eslint-config-qiwi: "npm:1.17.6"
     fast-glob: "npm:3.2.12"
     file-loader: "npm:6.2.0"
-    markdown-to-jsx: "npm:^7.4.0"
+    markdown-to-jsx: "npm:^7.7.3"
     prettier: "npm:2.8.8"
     prettier-config-qiwi: "npm:1.7.2"
     react: "npm:18.2.0"
@@ -8442,12 +8442,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:^7.4.0":
-  version: 7.6.2
-  resolution: "markdown-to-jsx@npm:7.6.2"
+"markdown-to-jsx@npm:^7.7.3":
+  version: 7.7.3
+  resolution: "markdown-to-jsx@npm:7.7.3"
   peerDependencies:
     react: ">= 0.14.0"
-  checksum: eecfeba9fbd99f6b312687c7379b6b8e5612770000ebbea60528315e674ead44ba877d984011d4c41f0dc123072be4244e4c354d75cdbd537e7eaf140fe7019b
+  checksum: 6da0f4937d063a5e14bc725d6ccb162aaa8807a5cdb55d935d6af8c2a98b48bf421b185d74b520c6d80b17f6f2aec3bf91d4b67f811099cf9a3fcc360c7e8862
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Поднимаю версию markdown-to-jsx для возможности использовать options.disableAutoLink в компонента Markdown

<!-- 
Add a link to issue, another PR, discussion with which this PR is associated.
Select the most suitable relation type: fixes / closes / relates
-->
Fixes [#id]
<!-- Maybe you'd like to discuss this at first? Your may always create a new issue / discussion topic -->

## Changes
<!-- What exactly you have changed, and how it works now -->

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
