### PR TITLE
refactor: remove deprecated findDOMNode

### DIFF
--- a/packages/core/src/main/ts/menu/MenuControl.ts
+++ b/packages/core/src/main/ts/menu/MenuControl.ts
@@ -5,7 +5,6 @@ import {
   MouseEventHandler,
   RefObject,
 } from 'react'
-import { findDOMNode } from 'react-dom'
 
 import { MenuControlProps } from './MenuControlProps'
 import { MenuControlState } from './MenuControlState'
@@ -74,10 +73,8 @@ export class MenuControl extends Component<MenuControlProps, MenuControlState> {
   }
 
   private scrollToItem: (item: RefObject<HTMLDivElement>) => void = (item) => {
-    const containerElement = findDOMNode(
-      this.containerRef.current,
-    ) as HTMLDivElement
-    const itemElement = findDOMNode(item.current) as HTMLDivElement
+    const containerElement = this.containerRef.current
+    const itemElement = item.current
     if (!containerElement || !itemElement) {
       return
     }

--- a/packages/core/src/main/ts/phone-field/PhoneFieldControl.ts
+++ b/packages/core/src/main/ts/phone-field/PhoneFieldControl.ts
@@ -6,7 +6,6 @@ import {
   MouseEventHandler,
   RefObject,
 } from 'react'
-import { findDOMNode } from 'react-dom'
 
 import { createPhoneMask } from '../mask'
 import { PhoneFieldControlProps } from './PhoneFieldControlProps'
@@ -91,7 +90,7 @@ export class PhoneFieldControl extends Component<
   }
 
   private get inputField(): HTMLInputElement {
-    return findDOMNode(this.inputRef.current!) as HTMLInputElement
+    return this.inputRef.current!
   }
 
   private onFlagClick: MouseEventHandler = (event) => {

--- a/packages/core/src/main/ts/tabs/TabsControl.ts
+++ b/packages/core/src/main/ts/tabs/TabsControl.ts
@@ -7,8 +7,6 @@ import {
   MouseEventHandler,
   RefObject,
 } from 'react'
-import { findDOMNode } from 'react-dom'
-
 export interface TabsControlProps {
   select: number
   length: number
@@ -48,9 +46,10 @@ export class TabsControl extends Component<TabsControlProps> {
   }
 
   private calculateBorder() {
-    const element = findDOMNode(
-      this.state.refs[this.props.select].current,
-    ) as HTMLDivElement
+    const element = this.state.refs[this.props.select].current
+    if (!element) {
+      return
+    }
     this.setState({
       borderLeft: element.offsetLeft,
       borderWidth: element.offsetWidth,


### PR DESCRIPTION
This API will be removed in a future major version of React. [See the alternatives.](https://18.react.dev/reference/react-dom/findDOMNode#alternatives)

https://18.react.dev/reference/react-dom/findDOMNode